### PR TITLE
require ext

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "ATLPay APIv2 Integration PHP SDK",
     "type": "library",
     "require": {
-        "ext-curl": "^0.0.0",
-        "ext-json": "^1.2",
-        "ext-mbstring": "^0.0.0"
+        "ext-curl": ">=0.0.0",
+        "ext-json": ">=1.2",
+        "ext-mbstring": ">=0.0.0"
     },
 	"autoload": {
         "psr-4": { "ATLPay\\": "src/" }


### PR DESCRIPTION
Fix minimum version of "ext-curl" and "ext-mbstring"